### PR TITLE
Add FOUNDATION_ADDRESS constant and update contact information in pages

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import Container from "@/app/_components/container";
+import { FOUNDATION_ADDRESS } from "@/lib/constants";
 
 export default function Contact() {
   return (
@@ -33,10 +34,8 @@ export default function Contact() {
                   
                   <div>
                     <h3 className="font-semibold text-lg mb-2">Mailing Address</h3>
-                    <p className="text-gray-700">
-                      Hillsdale Community Foundation<br />
-                      P.O. Box 14592<br />
-                      Portland, OR 97293
+                    <p className="text-gray-700 whitespace-pre-line">
+                      {FOUNDATION_ADDRESS}
                     </p>
                   </div>
                   

--- a/src/app/get-involved/page.tsx
+++ b/src/app/get-involved/page.tsx
@@ -1,6 +1,7 @@
 import Container from "@/app/_components/container";
 import Link from "next/link";
 import DonateButton from "@/app/_components/donate-button";
+import { FOUNDATION_ADDRESS } from "@/lib/constants";
 
 export default function GetInvolved() {
   return (
@@ -36,10 +37,8 @@ export default function GetInvolved() {
               </div>
                 <div className="space-y-4">
                 <p className="font-semibold">Or send checks to:</p>
-                <address className="not-italic">
-                  Hillsdale Community Foundation<br />
-                  1528 SW PENDLETON ST<br />
-                  97239-2618
+                <address className="not-italic whitespace-pre-line">
+                  {FOUNDATION_ADDRESS}
                 </address>
               </div>
             </section>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,3 +2,4 @@ export const EXAMPLE_PATH = "blog-starter";
 export const CMS_NAME = "Markdown";
 export const HOME_OG_IMAGE_URL =
   "https://og-image.vercel.app/Next.js%20Blog%20Starter%20Example.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg";
+export const FOUNDATION_ADDRESS = `Hillsdale Community Foundation\n1528 SW PENDLETON ST\n97239-2618`;


### PR DESCRIPTION
The canonical Pendleton address is now centralized in constants.ts as FOUNDATION_ADDRESS and used in both the Contact and Get Involved pages. All hardcoded instances have been replaced, and there are no errors in the updated files.

This resolves issue #16. If you need the address used elsewhere, you can now import and use FOUNDATION_ADDRESS from @/lib/constants.